### PR TITLE
Run constant-time comparison examples on equal-length input

### DIFF
--- a/example_non_ct/src/main.rs
+++ b/example_non_ct/src/main.rs
@@ -1,7 +1,12 @@
 
 fn main() {
-    fn not_constant_time_comparison(message: &[u8]) -> bool {
-        message == b"NOT CONSTANT TIME COMPARISON"
+    fn not_constant_time_comparison(m1: &[u8]) -> bool {
+        let mut m2 = m1.to_vec();
+        if !m2.is_empty() {
+            m2[0] ^= m1[0];
+        }
+
+        m1 == &m2[..]
     }
 
     let fuzzer = sidefuzz::SideFuzz::new(28, |message: &[u8]| {

--- a/subtle_ct_eq/src/main.rs
+++ b/subtle_ct_eq/src/main.rs
@@ -3,8 +3,13 @@ use subtle::ConstantTimeEq;
 fn main() {
     println!("This example target should be constant time, so it will never exit.");
 
-    let fuzzer = sidefuzz::SideFuzz::new(24, |message: &[u8]| {
-        sidefuzz::black_box(message.ct_eq(b"CONSTANT TIME COMPARISON"));
+    let fuzzer = sidefuzz::SideFuzz::new(24, |m1: &[u8]| {
+        let mut m2 = m1.to_vec();
+        if !m2.is_empty() {
+            m2[0] ^= m1[0];
+        }
+
+        sidefuzz::black_box(m2.ct_eq(m1));
         Ok(())
     });
 


### PR DESCRIPTION
Currently the variable-time and constant-time examples run with a `&[u8]` and some constant string literal. This doesn't seem to guarantee that the slice `message` always will be the same length as the constant string literal, so these examples run subtle's `ct_eq()` on slices with different lengths. subtle short-circuits on such inputs, so this changes the input to both of the examples to be of equal-length.